### PR TITLE
Remove react and react-native from the dependencies

### DIFF
--- a/native/package.json
+++ b/native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galette/native",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "scripts": {
     "release": "npm run build && npm publish",
     "test": "jest",
@@ -8,8 +8,6 @@
     "build-ts": "tsc"
   },
   "dependencies": {
-    "react": "^16.3.0-alpha.1",
-    "react-native": "0.54.3",
     "react-native-elements": "^0.19.1",
     "react-native-scrollable-mixin": "^1.0.1",
     "react-native-vector-icons": "^4.6.0",
@@ -28,7 +26,9 @@
     "react-native-typescript-transformer": "^1.2.3",
     "react-test-renderer": "^16.3.0-alpha.1",
     "ts-jest": "^22.4.2",
-    "typescript": "^2.8.1"
+    "typescript": "^2.8.1",
+    "react": "^16.3.0-alpha.1",
+    "react-native": "0.54.3"
   },
   "jest": {
     "preset": "react-native",


### PR DESCRIPTION
Let the application manage these dependencies, they will be here anyway when using `@galette/native`