### PR TITLE
Add typed action creator

### DIFF
--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -1,7 +1,9 @@
 import * as store from "./store"
 import * as hydra from "./hydra"
+import typedActionCreatorFactory from "./typed-action-creator/factory";
 
 export {
   store,
-  hydra
+  hydra,
+  typedActionCreatorFactory,
 }

--- a/core/src/typed-action-creator/README.md
+++ b/core/src/typed-action-creator/README.md
@@ -1,0 +1,52 @@
+# Typed Action
+
+`export`ing action types and action creators, that's enough! This "typed action creator"
+factory will allow you to refer to the type from the action creator directly.
+
+## Usage
+
+1. Create your action creator.
+   ```javascript
+   // actions.js
+
+   import { typedActionCreatorFactory } from '@galette/core';
+
+   export const loadUser = typedActionCreatorFactory('LOAD_USER', username => ({ username }));
+   ```
+
+2. Uses your action type from the creator
+   ```javascript
+   // reducers.js
+   import { loadUser } from './actions';
+
+   export const someReducer = (state, action) => {
+     if (action.type === loadUser.type) {
+       // do something...
+     }
+   }
+   ```
+
+3. Enjoy!
+
+## Reference: Action properties
+
+The 2nd parameter of the `typedActionCreatorFactory` is the function that will
+transform the arguments given to the action creator to the properties within the
+action.
+
+```javascript
+const loadTravels = typedActionCreatorFactory('LOAD_TRAVELS', (location, page = 1) => {
+  return {
+    location,
+    page,
+  }
+});
+
+const action = loadTravels('London', 2);
+
+expect(action).toEqual({
+  type: 'LOAD_TRAVELS',
+  location: 'Rennes',
+  page: 2
+})
+```

--- a/core/src/typed-action-creator/factory.ts
+++ b/core/src/typed-action-creator/factory.ts
@@ -1,0 +1,16 @@
+
+export default function typedActionCreatorFactory(type: string, resolver: () => any)
+{
+  const creator = (...args) => {
+    const properties = resolver.apply(null, args);
+
+    return {
+      type,
+      ...properties
+    }
+  }
+
+  creator.type = type;
+
+  return creator;
+}

--- a/core/tests/typed-action-creator/factory.test.ts
+++ b/core/tests/typed-action-creator/factory.test.ts
@@ -1,0 +1,30 @@
+import { typedActionCreatorFactory } from "../../src/index";
+
+describe('Typed action', () => {
+  it('returns an action creator for the given type', () => {
+    const loadUser = typedActionCreatorFactory('LOAD_USER', user => ({ user }));
+
+    expect(loadUser({ username: 'samuel' })).toEqual({
+      type: 'LOAD_USER',
+      user: {
+        username: 'samuel'
+      }
+    })
+  })
+
+  it('exposes the type as a property of the creator', () => {
+    const loadUser = typedActionCreatorFactory('LOAD_USER', user => ({ user }));
+
+    expect(loadUser.type).toEqual('LOAD_USER');
+  })
+
+  it('supports multiple arguments', () => {
+    const loadTravels = typedActionCreatorFactory('LOAD_TRAVELS', (location, page) => ({ location, page }));
+
+    expect(loadTravels('Rennes', 2)).toEqual({
+      type: 'LOAD_TRAVELS',
+      location: 'Rennes',
+      page: 2
+    })
+  })
+})


### PR DESCRIPTION
Explained in the `README.md` file. TL;DR: No more of `export` the action type and the action creator.