### PR TITLE
We can have arguments in resolvers

### DIFF
--- a/core/src/typed-action-creator/factory.ts
+++ b/core/src/typed-action-creator/factory.ts
@@ -1,9 +1,10 @@
+type PropertiesResolver = (...args : any[]) => any;
 type ActionCreator = (...args : any[]) => any;
 type ActionCreatorWithType = ActionCreator & {
   type: string;
 }
 
-export default function typedActionCreatorFactory(type: string, resolver: () => any) : ActionCreatorWithType
+export default function typedActionCreatorFactory(type: string, resolver: PropertiesResolver) : ActionCreatorWithType
 {
   const creator : ActionCreator = (...args : any[]) => {
     const properties = resolver.apply(null, args);


### PR DESCRIPTION
Because we love types.