### PR TITLE
Add a custom error message resolver and only reduces error messages

### DIFF
--- a/core/src/store/redux/reducers.ts
+++ b/core/src/store/redux/reducers.ts
@@ -27,6 +27,7 @@ export type ActionLifecycleOptions = {
 export type ReduceListOptions = ReduceItemsOptions & ActionLifecycleOptions & {
   listKeyInState: string;
 
+  errorMessageResolver?: (action: Action) => string;
   totalItems?: (action: Action) => number;
 };
 
@@ -35,7 +36,7 @@ export type ReducedList = {
 
   up_to_page?: number;
   loading?: number;
-  error?: any;
+  error?: string;
   total_items?: number;
 };
 
@@ -62,6 +63,12 @@ function itemsFromAction(action: Action, options: ReduceItemsOptions) {
 
   return items;
 }
+
+const defaultErrorMessageResolver = (action: Action) => {
+  const messageSource = action.error || action.payload || {};
+
+  return messageSource.message || messageSource.error || 'Something went wrong.';
+};
 
 export const reduceItems = (state = {}, action : Action, options : ReduceItemsOptions) => {
   let items = itemsFromAction(action, options);
@@ -119,9 +126,10 @@ export const reduceList = (state : any = {}, action : Action, options : ReduceLi
   }
 
   if (action.type === options.actions.failed) {
+    const errorResolver = options.errorMessageResolver ? options.errorMessageResolver : defaultErrorMessageResolver;
     return updateItem(state, options.listKeyInState, {
       loading: false,
-      error: action.error || action.payload,
+      error: errorResolver(action),
     });
   }
 

--- a/core/tests/store/redux/reducers.list.test.ts
+++ b/core/tests/store/redux/reducers.list.test.ts
@@ -40,9 +40,7 @@ describe('Reduce list of items', () => {
     expect(reduced).toEqual({
       list: {
         loading: false,
-        error: {
-          message: 'Invalid something...'
-        }
+        error: 'Invalid something...'
       }
     })
   })
@@ -90,7 +88,36 @@ describe('Reduce list of items', () => {
     expect(state).toEqual({
       list: {
         loading: false,
-        error: { oups: 'Meh' }
+        error: 'Something went wrong.'
+      }
+    })
+  })
+
+  it('supports a custom error message resolver', () => {
+    const reduced = reduceList({
+      list: {
+        loading: true,
+        error: null,
+      }
+    }, {
+      type: 'MY_ACTION_FAILED',
+      payload: {
+        error: {
+          myComplexErrorSchema: 'With a message'
+        }
+      }
+    }, {
+      items: [],
+      itemIdentifierResolver: (item : any) => item.id,
+      actionPrefix: 'MY_ACTION',
+      listKeyInState: 'list',
+      errorMessageResolver: (action: any) => action.payload.error.myComplexErrorSchema,
+    })
+
+    expect(reduced).toEqual({
+      list: {
+        loading: false,
+        error: 'With a message'
       }
     })
   })


### PR DESCRIPTION
Reducing the `error` or the `payload` on persisted stores (when used with React Native for example) is very risky as it can be super big.

This change forces the reduced error to be a string and it allows to pass a custom option to resolve the error string the way we want.